### PR TITLE
npm run buildでこけるので、一時的にwebpack --mode developmentで対処

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,4 +4,5 @@ RUN export PATH=$PATH:node_modules/.bin
 CMD rm -rf dist/* && \
     rm -rf node_modules/* && \
     npm install && \
-    npm run build
+    webpack --mode development
+    # npm run build


### PR DESCRIPTION
なんで `npm run build` が通らないのか明日まで考えといて下さい。 そしたらなにか分かるはずです。

たぶんこれ

http://top-men.hatenablog.com/entry/2018/02/27/031345